### PR TITLE
chore: make it compatible with phpcodesniffer-composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "totara/codesniffer",
     "description": "PHP Code Sniffer standard for Totara Coding Style.",
-    "type": "project",
+    "type": "phpcodesniffer-standard",
     "keywords": [
         "phpcs",
         "standards",


### PR DESCRIPTION
By changing the type on `composer.json` we allow the Totara code standard to be required via composer:

```
composer require --dev totara/codesniffer=dev-master
```
To have it working I also submitted the repository to Packegist (I hope you don't mind).

The Packegist page can be found here: https://packagist.org/packages/totara/codesniffer

For testing purposes, I also registered my fork on Packegist so we can run:
```
composer require --dev eher/totara-code-sniffer=dev-master
```
and check it with:
```
vendor/bin/phpcs -i
```